### PR TITLE
Feat: Add user table and edit modal to Customers page

### DIFF
--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -1,0 +1,356 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onUserUpdated: () => void;
+}
+
+const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
+
+export default function CrmEditUserModal({
+  open,
+  user,
+  onClose,
+  onUserUpdated,
+}: EditUserModalProps) {
+  const [formData, setFormData] = React.useState<Partial<User>>({});
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  React.useEffect(() => {
+    if (user) {
+      setFormData(user);
+      setError(null);
+      setSuccess(false);
+    }
+  }, [user]);
+
+  const handleChange = (field: string, value: any) => {
+    setFormData((prev) => {
+      const keys = field.split(".");
+      if (keys.length === 1) {
+        return { ...prev, [field]: value };
+      }
+
+      const newData = { ...prev };
+      let current: any = newData;
+
+      for (let i = 0; i < keys.length - 1; i++) {
+        if (!current[keys[i]]) {
+          current[keys[i]] = {};
+        } else {
+          current[keys[i]] = { ...current[keys[i]] };
+        }
+        current = current[keys[i]];
+      }
+
+      current[keys[keys.length - 1]] = value;
+      return newData;
+    });
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/users/${user.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(formData),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update user");
+      }
+
+      setSuccess(true);
+      setTimeout(() => {
+        onUserUpdated();
+        onClose();
+      }, 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update user");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        component: "form",
+        onSubmit: handleSubmit,
+      }}
+    >
+      <DialogTitle>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar
+            src={user.picture.large}
+            alt={`${formData.name?.first} ${formData.name?.last}`}
+            sx={{ width: 56, height: 56 }}
+          />
+          <Box>
+            <Typography variant="h6">Edit User</Typography>
+            <Typography variant="body2" color="text.secondary">
+              @{user.login.username}
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={3}>
+          {error && <Alert severity="error">{error}</Alert>}
+          {success && (
+            <Alert severity="success">User updated successfully!</Alert>
+          )}
+
+          <Typography variant="subtitle2" color="text.secondary">
+            Personal Information
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={2}>
+              <FormControl fullWidth>
+                <InputLabel>Title</InputLabel>
+                <Select
+                  value={formData.name?.title || ""}
+                  label="Title"
+                  onChange={(e) => handleChange("name.title", e.target.value)}
+                >
+                  <MenuItem value="Mr">Mr</MenuItem>
+                  <MenuItem value="Mrs">Mrs</MenuItem>
+                  <MenuItem value="Ms">Ms</MenuItem>
+                  <MenuItem value="Miss">Miss</MenuItem>
+                  <MenuItem value="Dr">Dr</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={5}>
+              <TextField
+                fullWidth
+                label="First Name"
+                value={formData.name?.first || ""}
+                onChange={(e) => handleChange("name.first", e.target.value)}
+                required
+              />
+            </Grid>
+            <Grid item xs={12} sm={5}>
+              <TextField
+                fullWidth
+                label="Last Name"
+                value={formData.name?.last || ""}
+                onChange={(e) => handleChange("name.last", e.target.value)}
+                required
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Email"
+                type="email"
+                value={formData.email || ""}
+                onChange={(e) => handleChange("email", e.target.value)}
+                required
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <FormControl fullWidth>
+                <InputLabel>Gender</InputLabel>
+                <Select
+                  value={formData.gender || ""}
+                  label="Gender"
+                  onChange={(e) => handleChange("gender", e.target.value)}
+                >
+                  <MenuItem value="male">Male</MenuItem>
+                  <MenuItem value="female">Female</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          <Typography variant="subtitle2" color="text.secondary">
+            Contact Information
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Phone"
+                value={formData.phone || ""}
+                onChange={(e) => handleChange("phone", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Cell"
+                value={formData.cell || ""}
+                onChange={(e) => handleChange("cell", e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Typography variant="subtitle2" color="text.secondary">
+            Address
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={3}>
+              <TextField
+                fullWidth
+                label="Street Number"
+                type="number"
+                value={formData.location?.street?.number || ""}
+                onChange={(e) =>
+                  handleChange("location.street.number", parseInt(e.target.value))
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={9}>
+              <TextField
+                fullWidth
+                label="Street Name"
+                value={formData.location?.street?.name || ""}
+                onChange={(e) =>
+                  handleChange("location.street.name", e.target.value)
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="City"
+                value={formData.location?.city || ""}
+                onChange={(e) => handleChange("location.city", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="State"
+                value={formData.location?.state || ""}
+                onChange={(e) => handleChange("location.state", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Country"
+                value={formData.location?.country || ""}
+                onChange={(e) =>
+                  handleChange("location.country", e.target.value)
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Postcode"
+                value={formData.location?.postcode || ""}
+                onChange={(e) =>
+                  handleChange("location.postcode", e.target.value)
+                }
+              />
+            </Grid>
+          </Grid>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={20} /> : null}
+        >
+          {loading ? "Saving..." : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -1,0 +1,311 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import InputBase from "@mui/material/InputBase";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import { alpha, styled } from "@mui/material/styles";
+import Chip from "@mui/material/Chip";
+import TablePagination from "@mui/material/TablePagination";
+import CircularProgress from "@mui/material/CircularProgress";
+
+const SearchWrapper = styled("div")(({ theme }) => ({
+  position: "relative",
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: alpha(theme.palette.common.black, 0.04),
+  "&:hover": {
+    backgroundColor: alpha(theme.palette.common.black, 0.06),
+  },
+  width: "100%",
+  maxWidth: 400,
+  ...theme.applyStyles("dark", {
+    backgroundColor: alpha(theme.palette.common.white, 0.06),
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.common.white, 0.1),
+    },
+  }),
+}));
+
+const SearchIconWrapper = styled("div")(({ theme }) => ({
+  padding: theme.spacing(0, 2),
+  height: "100%",
+  position: "absolute",
+  pointerEvents: "none",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+}));
+
+const StyledInputBase = styled(InputBase)(({ theme }) => ({
+  color: "inherit",
+  width: "100%",
+  "& .MuiInputBase-input": {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+    transition: theme.transitions.create("width"),
+    width: "100%",
+  },
+}));
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+interface UsersTableProps {
+  onEditUser: (user: User) => void;
+}
+
+const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
+
+export default function CrmUsersTable({ onEditUser }: UsersTableProps) {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchTerm, setSearchTerm] = React.useState("");
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+  const [totalUsers, setTotalUsers] = React.useState(0);
+
+  const fetchUsers = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(page + 1),
+        perPage: String(rowsPerPage),
+        ...(searchTerm && { search: searchTerm }),
+      });
+
+      const response = await fetch(`${API_BASE_URL}/users?${params}`);
+      const data = await response.json();
+
+      setUsers(data.data || []);
+      setTotalUsers(data.total || 0);
+    } catch (error) {
+      console.error("Error fetching users:", error);
+      setUsers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, rowsPerPage, searchTerm]);
+
+  React.useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+    setPage(0);
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const formatDate = (dateString: string) => {
+    const options: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    };
+    return new Date(dateString).toLocaleDateString("en-US", options);
+  };
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <CardContent sx={{ pb: 2 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          justifyContent="space-between"
+          alignItems={{ xs: "stretch", sm: "center" }}
+          spacing={2}
+          sx={{ mb: 2 }}
+        >
+          <Typography variant="h6" component="h2">
+            Users
+          </Typography>
+          <SearchWrapper>
+            <SearchIconWrapper>
+              <SearchRoundedIcon fontSize="small" />
+            </SearchIconWrapper>
+            <StyledInputBase
+              placeholder="Search users..."
+              inputProps={{ "aria-label": "search users" }}
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
+          </SearchWrapper>
+        </Stack>
+      </CardContent>
+      <TableContainer sx={{ flexGrow: 1 }}>
+        <Table size="small" aria-label="users table">
+          <TableHead>
+            <TableRow>
+              <TableCell>User</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Location</TableCell>
+              <TableCell>Phone</TableCell>
+              <TableCell>Age</TableCell>
+              <TableCell>Gender</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 8 }}>
+                  <CircularProgress size={40} />
+                </TableCell>
+              </TableRow>
+            ) : users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 8 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    No users found
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => (
+                <TableRow key={user.login.uuid} hover>
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Avatar
+                        src={user.picture.thumbnail}
+                        alt={`${user.name.first} ${user.name.last}`}
+                        sx={{ width: 32, height: 32 }}
+                      />
+                      <Box>
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                          {user.name.first} {user.name.last}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: "block" }}
+                        >
+                          @{user.login.username}
+                        </Typography>
+                      </Box>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{user.email}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">
+                      {user.location.city}, {user.location.state}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {user.location.country}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{user.phone}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{user.dob.age}</Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      label={user.gender}
+                      size="small"
+                      variant="outlined"
+                      color={user.gender === "male" ? "primary" : "secondary"}
+                    />
+                  </TableCell>
+                  <TableCell align="right">
+                    <IconButton
+                      size="small"
+                      aria-label="edit user"
+                      onClick={() => onEditUser(user)}
+                    >
+                      <EditRoundedIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[5, 10, 25, 50]}
+        component="div"
+        count={totalUsers}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Card>
+  );
+}

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,92 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CrmUsersTable from "../components/CrmUsersTable";
+import CrmEditUserModal from "../components/CrmEditUserModal";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
 
 export default function Customers() {
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const [refreshKey, setRefreshKey] = React.useState(0);
+
+  const handleEditUser = (user: User) => {
+    setSelectedUser(user);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleUserUpdated = () => {
+    setRefreshKey((prev) => prev + 1);
+  };
+
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
+      <Typography paragraph color="text.secondary" sx={{ mb: 3 }}>
+        Manage your customer data, search users, and update their information.
       </Typography>
+      <CrmUsersTable key={refreshKey} onEditUser={handleEditUser} />
+      <CrmEditUserModal
+        open={modalOpen}
+        user={selectedUser}
+        onClose={handleCloseModal}
+        onUserUpdated={handleUserUpdated}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
### Purpose

The user wanted to add a table of users to the "Customers" tab. The goal was to fetch user data from the Users API, display it in a table, and allow for searching and editing of user information within a modal.

### Code changes

- **`CrmUsersTable.tsx`**: A new component was created to display a paginated and searchable table of users. It fetches data from the `/api/users` endpoint.
- **`CrmEditUserModal.tsx`**: This new component provides a modal form to edit user details. It submits updates via a `PUT` request to the user API.
- **`Customers.tsx`**: The main customers page was updated to integrate the new `CrmUsersTable` and `CrmEditUserModal` components. It now handles the state for opening the edit modal and refreshing the user list after an update.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/732f251a2f7347b08695f539bfd6f8a7/echo-forge)

👀 [Preview Link](https://732f251a2f7347b08695f539bfd6f8a7-echo-forge.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>732f251a2f7347b08695f539bfd6f8a7</projectId>-->
<!--<branchName>echo-forge</branchName>-->