### PR TITLE
Add customers table with search and edit modal

### DIFF
--- a/src/crm/components/CustomersTable.tsx
+++ b/src/crm/components/CustomersTable.tsx
@@ -1,0 +1,345 @@
+import * as React from "react";
+import { DataGrid, GridColDef, GridActionsCellItem } from "@mui/x-data-grid";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Avatar from "@mui/material/Avatar";
+import Chip from "@mui/material/Chip";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import InputBase from "@mui/material/InputBase";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import { alpha, styled } from "@mui/material/styles";
+import Stack from "@mui/material/Stack";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import EditUserModal from "./EditUserModal";
+
+const SearchWrapper = styled("div")(({ theme }) => ({
+  position: "relative",
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: alpha(theme.palette.common.black, 0.04),
+  "&:hover": {
+    backgroundColor: alpha(theme.palette.common.black, 0.06),
+  },
+  width: "100%",
+  maxWidth: 400,
+  ...theme.applyStyles("dark", {
+    backgroundColor: alpha(theme.palette.common.white, 0.06),
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.common.white, 0.1),
+    },
+  }),
+}));
+
+const SearchIconWrapper = styled("div")(({ theme }) => ({
+  padding: theme.spacing(0, 2),
+  height: "100%",
+  position: "absolute",
+  pointerEvents: "none",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+}));
+
+const StyledInputBase = styled(InputBase)(({ theme }) => ({
+  color: "inherit",
+  width: "100%",
+  "& .MuiInputBase-input": {
+    padding: theme.spacing(1, 1, 1, 0),
+    paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+    width: "100%",
+  },
+}));
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture?: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+export default function CustomersTable() {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [filteredUsers, setFilteredUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [editingUser, setEditingUser] = React.useState<User | null>(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  React.useEffect(() => {
+    if (searchQuery.trim() === "") {
+      setFilteredUsers(users);
+    } else {
+      const query = searchQuery.toLowerCase();
+      const filtered = users.filter(
+        (user) =>
+          user.name.first.toLowerCase().includes(query) ||
+          user.name.last.toLowerCase().includes(query) ||
+          user.email.toLowerCase().includes(query) ||
+          user.location.city.toLowerCase().includes(query) ||
+          user.location.country.toLowerCase().includes(query) ||
+          user.login.username.toLowerCase().includes(query)
+      );
+      setFilteredUsers(filtered);
+    }
+  }, [searchQuery, users]);
+
+  const fetchUsers = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(
+        "https://user-api.builder-io.workers.dev/api/users?perPage=100"
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch users");
+      }
+      const data = await response.json();
+      setUsers(data.data || []);
+      setFilteredUsers(data.data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (user: User) => {
+    setEditingUser(user);
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setEditingUser(null);
+  };
+
+  const handleUpdateUser = async (updatedUser: User) => {
+    // Update local state
+    const updatedUsers = users.map((u) =>
+      u.login.uuid === updatedUser.login.uuid ? updatedUser : u
+    );
+    setUsers(updatedUsers);
+    setFilteredUsers(updatedUsers);
+    handleCloseModal();
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "avatar",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <Avatar
+          src={params.row.picture?.thumbnail}
+          alt={`${params.row.name.first} ${params.row.name.last}`}
+          sx={{ width: 32, height: 32 }}
+        >
+          {params.row.name.first[0]}
+          {params.row.name.last[0]}
+        </Avatar>
+      ),
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      width: 200,
+      valueGetter: (value, row) =>
+        `${row.name.title} ${row.name.first} ${row.name.last}`,
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      width: 250,
+      flex: 1,
+    },
+    {
+      field: "username",
+      headerName: "Username",
+      width: 150,
+      valueGetter: (value, row) => row.login.username,
+    },
+    {
+      field: "location",
+      headerName: "Location",
+      width: 200,
+      valueGetter: (value, row) =>
+        `${row.location.city}, ${row.location.country}`,
+    },
+    {
+      field: "age",
+      headerName: "Age",
+      width: 80,
+      type: "number",
+      valueGetter: (value, row) => row.dob.age,
+    },
+    {
+      field: "phone",
+      headerName: "Phone",
+      width: 150,
+    },
+    {
+      field: "gender",
+      headerName: "Gender",
+      width: 100,
+      renderCell: (params) => (
+        <Chip
+          label={params.value}
+          size="small"
+          color={params.value === "male" ? "primary" : "secondary"}
+          variant="outlined"
+        />
+      ),
+    },
+    {
+      field: "actions",
+      type: "actions",
+      headerName: "Actions",
+      width: 80,
+      getActions: (params) => [
+        <GridActionsCellItem
+          icon={<EditRoundedIcon />}
+          label="Edit"
+          onClick={() => handleEdit(params.row)}
+          showInMenu={false}
+        />,
+      ],
+    },
+  ];
+
+  const rows = filteredUsers.map((user) => ({
+    id: user.login.uuid,
+    ...user,
+  }));
+
+  if (error) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Alert severity="error">{error}</Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card variant="outlined">
+        <CardContent>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+            spacing={2}
+            sx={{ mb: 3 }}
+          >
+            <Typography variant="h6" component="h2">
+              Customers
+            </Typography>
+            <SearchWrapper>
+              <SearchIconWrapper>
+                <SearchRoundedIcon fontSize="small" />
+              </SearchIconWrapper>
+              <StyledInputBase
+                placeholder="Search customers…"
+                inputProps={{ "aria-label": "search" }}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </SearchWrapper>
+          </Stack>
+          <Box sx={{ height: 600, width: "100%" }}>
+            {loading ? (
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  height: "100%",
+                }}
+              >
+                <CircularProgress />
+              </Box>
+            ) : (
+              <DataGrid
+                rows={rows}
+                columns={columns}
+                initialState={{
+                  pagination: { paginationModel: { pageSize: 10 } },
+                }}
+                pageSizeOptions={[10, 25, 50, 100]}
+                disableColumnResize
+                density="comfortable"
+                sx={{
+                  border: 0,
+                  "& .MuiDataGrid-cell:focus": {
+                    outline: "none",
+                  },
+                  "& .MuiDataGrid-cell:focus-within": {
+                    outline: "none",
+                  },
+                }}
+              />
+            )}
+          </Box>
+        </CardContent>
+      </Card>
+      <EditUserModal
+        open={modalOpen}
+        user={editingUser}
+        onClose={handleCloseModal}
+        onSave={handleUpdateUser}
+      />
+    </>
+  );
+}

--- a/src/crm/components/EditUserModal.tsx
+++ b/src/crm/components/EditUserModal.tsx
@@ -1,0 +1,351 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Grid from "@mui/material/Grid";
+import MenuItem from "@mui/material/MenuItem";
+import Box from "@mui/material/Box";
+import Avatar from "@mui/material/Avatar";
+import Typography from "@mui/material/Typography";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell: string;
+  picture?: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onSave: (user: User) => void;
+}
+
+export default function EditUserModal({
+  open,
+  user,
+  onClose,
+  onSave,
+}: EditUserModalProps) {
+  const [formData, setFormData] = React.useState<User | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (user) {
+      setFormData({ ...user });
+      setError(null);
+    }
+  }, [user]);
+
+  const handleChange = (field: string, value: any) => {
+    if (!formData) return;
+
+    const fields = field.split(".");
+    const newData = { ...formData };
+    let current: any = newData;
+
+    for (let i = 0; i < fields.length - 1; i++) {
+      current[fields[i]] = { ...current[fields[i]] };
+      current = current[fields[i]];
+    }
+
+    current[fields[fields.length - 1]] = value;
+    setFormData(newData);
+  };
+
+  const handleSubmit = async () => {
+    if (!formData) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${formData.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(formData),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update user");
+      }
+
+      onSave(formData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!formData) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: { borderRadius: 2 },
+      }}
+    >
+      <DialogTitle>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Avatar
+            src={formData.picture?.thumbnail}
+            alt={`${formData.name.first} ${formData.name.last}`}
+            sx={{ width: 48, height: 48 }}
+          >
+            {formData.name.first[0]}
+            {formData.name.last[0]}
+          </Avatar>
+          <Box>
+            <Typography variant="h6" component="div">
+              Edit Customer
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {formData.email}
+            </Typography>
+          </Box>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Grid container spacing={2}>
+          <Grid item xs={12} sm={4}>
+            <TextField
+              fullWidth
+              label="Title"
+              select
+              value={formData.name.title}
+              onChange={(e) => handleChange("name.title", e.target.value)}
+              disabled={loading}
+            >
+              <MenuItem value="Mr">Mr</MenuItem>
+              <MenuItem value="Mrs">Mrs</MenuItem>
+              <MenuItem value="Ms">Ms</MenuItem>
+              <MenuItem value="Miss">Miss</MenuItem>
+              <MenuItem value="Dr">Dr</MenuItem>
+            </TextField>
+          </Grid>
+          <Grid item xs={12} sm={4}>
+            <TextField
+              fullWidth
+              label="First Name"
+              value={formData.name.first}
+              onChange={(e) => handleChange("name.first", e.target.value)}
+              disabled={loading}
+              required
+            />
+          </Grid>
+          <Grid item xs={12} sm={4}>
+            <TextField
+              fullWidth
+              label="Last Name"
+              value={formData.name.last}
+              onChange={(e) => handleChange("name.last", e.target.value)}
+              disabled={loading}
+              required
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Email"
+              type="email"
+              value={formData.email}
+              onChange={(e) => handleChange("email", e.target.value)}
+              disabled={loading}
+              required
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Username"
+              value={formData.login.username}
+              onChange={(e) => handleChange("login.username", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Phone"
+              value={formData.phone}
+              onChange={(e) => handleChange("phone", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Cell"
+              value={formData.cell}
+              onChange={(e) => handleChange("cell", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Gender"
+              select
+              value={formData.gender}
+              onChange={(e) => handleChange("gender", e.target.value)}
+              disabled={loading}
+            >
+              <MenuItem value="male">Male</MenuItem>
+              <MenuItem value="female">Female</MenuItem>
+            </TextField>
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Nationality"
+              value={formData.nat}
+              onChange={(e) => handleChange("nat", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+              Address
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sm={3}>
+            <TextField
+              fullWidth
+              label="Street Number"
+              type="number"
+              value={formData.location.street.number}
+              onChange={(e) =>
+                handleChange("location.street.number", parseInt(e.target.value))
+              }
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={9}>
+            <TextField
+              fullWidth
+              label="Street Name"
+              value={formData.location.street.name}
+              onChange={(e) =>
+                handleChange("location.street.name", e.target.value)
+              }
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="City"
+              value={formData.location.city}
+              onChange={(e) => handleChange("location.city", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="State"
+              value={formData.location.state}
+              onChange={(e) => handleChange("location.state", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Country"
+              value={formData.location.country}
+              onChange={(e) => handleChange("location.country", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              fullWidth
+              label="Postcode"
+              value={formData.location.postcode}
+              onChange={(e) => handleChange("location.postcode", e.target.value)}
+              disabled={loading}
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {loading ? "Saving..." : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CustomersTable from "../components/CustomersTable";
 
 export default function Customers() {
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 3 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
-      </Typography>
+      <CustomersTable />
     </Box>
   );
 }


### PR DESCRIPTION
1. **Summary**: This PR implements a functional customers table on the Customers page, featuring user search capabilities and a modal for editing user details.

2. **Problem**: The Customers page was previously a static placeholder text without any ability to view or manage customer data.

3. **Solution**: I added a Material UI DataGrid to display user data fetched from an API, implemented client-side filtering for search, and created a dialog component to handle user updates.

4. **Key Changes**:
*   Implemented `CustomersTable` component with `DataGrid` for displaying user records.
*   Added search functionality to filter users by name, email, city, or username.
*   Created `EditUserModal` to allow editing user details (name, contact, address) via a PUT request.
*   Integrated the new table component into the main `Customers` page.

5. **Files Changed**:
*   `src/crm/components/CustomersTable.tsx`: New file containing the data grid and search logic.
*   `src/crm/components/EditUserModal.tsx`: New file containing the form modal for user editing.
*   `src/crm/pages/Customers.tsx`: Updated to render the `CustomersTable` instead of placeholder text.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/732f251a2f7347b08695f539bfd6f8a7/orbit-den)

👀 [Preview Link](https://732f251a2f7347b08695f539bfd6f8a7-orbit-den.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>732f251a2f7347b08695f539bfd6f8a7</projectId>-->
<!--<branchName>orbit-den</branchName>-->