### PR TITLE
Add users table with search and edit capabilities

### DIFF
--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,416 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchIcon from "@mui/icons-material/Search";
+import Paper from "@mui/material/Paper";
+import { DataGrid, GridColDef, GridRowParams } from "@mui/x-data-grid";
+import IconButton from "@mui/material/IconButton";
+import EditIcon from "@mui/icons-material/Edit";
+import Chip from "@mui/material/Chip";
+import Avatar from "@mui/material/Avatar";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password?: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob?: {
+    date: string;
+    age: number;
+  };
+  registered?: {
+    date: string;
+    age: number;
+  };
+  phone?: string;
+  cell?: string;
+  picture?: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat?: string;
+}
+
+interface EditFormData {
+  firstName: string;
+  lastName: string;
+  email: string;
+  city: string;
+  country: string;
+  phone: string;
+}
 
 export default function Customers() {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [editDialogOpen, setEditDialogOpen] = React.useState(false);
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+  const [editFormData, setEditFormData] = React.useState<EditFormData>({
+    firstName: "",
+    lastName: "",
+    email: "",
+    city: "",
+    country: "",
+    phone: "",
+  });
+  const [saveLoading, setSaveLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Fetch users from API
+  const fetchUsers = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users?perPage=100&search=${searchQuery}`
+      );
+      if (!response.ok) throw new Error("Failed to fetch users");
+      const data = await response.json();
+      setUsers(data.data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load users");
+    } finally {
+      setLoading(false);
+    }
+  }, [searchQuery]);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchUsers();
+    }, 300); // Debounce search
+
+    return () => clearTimeout(timer);
+  }, [fetchUsers]);
+
+  const handleEditClick = (user: User) => {
+    setSelectedUser(user);
+    setEditFormData({
+      firstName: user.name.first,
+      lastName: user.name.last,
+      email: user.email,
+      city: user.location.city,
+      country: user.location.country,
+      phone: user.phone || "",
+    });
+    setEditDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setEditDialogOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleSaveUser = async () => {
+    if (!selectedUser) return;
+
+    setSaveLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${selectedUser.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: {
+              first: editFormData.firstName,
+              last: editFormData.lastName,
+            },
+            email: editFormData.email,
+            location: {
+              city: editFormData.city,
+              country: editFormData.country,
+            },
+            phone: editFormData.phone,
+          }),
+        }
+      );
+
+      if (!response.ok) throw new Error("Failed to update user");
+
+      await fetchUsers(); // Refresh the list
+      handleCloseDialog();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save user");
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "avatar",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => {
+        const user = params.row as User;
+        return (
+          <Avatar
+            src={user.picture?.thumbnail}
+            alt={`${user.name.first} ${user.name.last}`}
+            sx={{ width: 32, height: 32 }}
+          >
+            {user.name.first[0]}
+            {user.name.last[0]}
+          </Avatar>
+        );
+      },
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 1,
+      minWidth: 150,
+      valueGetter: (value, row) => `${row.name.first} ${row.name.last}`,
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      flex: 1.5,
+      minWidth: 200,
+    },
+    {
+      field: "location",
+      headerName: "Location",
+      flex: 1,
+      minWidth: 150,
+      valueGetter: (value, row) =>
+        `${row.location.city}, ${row.location.country}`,
+    },
+    {
+      field: "phone",
+      headerName: "Phone",
+      flex: 1,
+      minWidth: 130,
+    },
+    {
+      field: "gender",
+      headerName: "Gender",
+      width: 100,
+      renderCell: (params) => (
+        <Chip
+          label={params.value}
+          size="small"
+          color={params.value === "male" ? "primary" : "secondary"}
+        />
+      ),
+    },
+    {
+      field: "actions",
+      headerName: "Actions",
+      width: 80,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <IconButton
+          size="small"
+          onClick={() => handleEditClick(params.row as User)}
+          aria-label="edit user"
+        >
+          <EditIcon fontSize="small" />
+        </IconButton>
+      ),
+    },
+  ];
+
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
+      <Typography paragraph sx={{ mb: 3, color: "text.secondary" }}>
+        Manage your customer data and user information.
       </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <TextField
+          fullWidth
+          variant="outlined"
+          placeholder="Search users by name, email, or city..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Paper>
+
+      <Paper sx={{ height: 600, width: "100%" }}>
+        <DataGrid
+          rows={users}
+          columns={columns}
+          loading={loading}
+          getRowId={(row) => row.login.uuid}
+          getRowClassName={(params) =>
+            params.indexRelativeToCurrentPage % 2 === 0 ? "even" : "odd"
+          }
+          initialState={{
+            pagination: { paginationModel: { pageSize: 20 } },
+          }}
+          pageSizeOptions={[10, 20, 50]}
+          density="compact"
+          disableColumnResize
+          slotProps={{
+            loadingOverlay: {
+              variant: "circular-progress",
+              noRowsVariant: "skeleton",
+            },
+          }}
+        />
+      </Paper>
+
+      <Dialog
+        open={editDialogOpen}
+        onClose={handleCloseDialog}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle>Edit User</DialogTitle>
+        <DialogContent>
+          <Box sx={{ mt: 2 }}>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="First Name"
+                  value={editFormData.firstName}
+                  onChange={(e) =>
+                    setEditFormData({
+                      ...editFormData,
+                      firstName: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Last Name"
+                  value={editFormData.lastName}
+                  onChange={(e) =>
+                    setEditFormData({
+                      ...editFormData,
+                      lastName: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Email"
+                  type="email"
+                  value={editFormData.email}
+                  onChange={(e) =>
+                    setEditFormData({ ...editFormData, email: e.target.value })
+                  }
+                  required
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="City"
+                  value={editFormData.city}
+                  onChange={(e) =>
+                    setEditFormData({ ...editFormData, city: e.target.value })
+                  }
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  fullWidth
+                  label="Country"
+                  value={editFormData.country}
+                  onChange={(e) =>
+                    setEditFormData({
+                      ...editFormData,
+                      country: e.target.value,
+                    })
+                  }
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Phone"
+                  value={editFormData.phone}
+                  onChange={(e) =>
+                    setEditFormData({ ...editFormData, phone: e.target.value })
+                  }
+                />
+              </Grid>
+            </Grid>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog} disabled={saveLoading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSaveUser}
+            variant="contained"
+            disabled={saveLoading}
+            startIcon={saveLoading ? <CircularProgress size={16} /> : null}
+          >
+            {saveLoading ? "Saving..." : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
This PR implements a full-featured users table in the Customers page, incorporating API integration, search functionality, and an edit modal for managing user data.

## Problem
The customers page was previously a static placeholder containing only text headers, which prevented users from viewing, searching, or managing customer data from the backend system.

## Solution
I replaced the static content with a Material-UI `DataGrid` that fetches data from the users API. I implemented a debounced search input for filtering records and added a dialog modal to enable editing of user details via a PUT request.

## Key Changes
*   **API Integration**: Connected to `https://user-api.builder-io.workers.dev/api/users` to fetch list data and update specific users.
*   **UI Components**: Added a `DataGrid` to display user attributes (Avatar, Name, Email, Location, Phone, Gender) and a Search bar.
*   **Edit Functionality**: Created a `Dialog` form to edit First Name, Last Name, Email, City, Country, and Phone.
*   **State Management**: Implemented state for loading, search queries, pagination, and form handling.
*   **Typing**: Added TypeScript interfaces for `User` data and `EditFormData`.

## Files Changed
*   `src/crm/pages/Customers.tsx`: Replaced placeholder text with the new users table, search logic, and edit modal implementation.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/732f251a2f7347b08695f539bfd6f8a7/vibe-lab)

👀 [Preview Link](https://732f251a2f7347b08695f539bfd6f8a7-vibe-lab.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>732f251a2f7347b08695f539bfd6f8a7</projectId>-->
<!--<branchName>vibe-lab</branchName>-->