### PR TITLE
Add searchable users table and edit modal to customers page

### DIFF
--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -1,3 +1,18 @@
+/**
+ * CRM Edit User Modal Component
+ *
+ * A comprehensive modal dialog for editing user information in the CRM system.
+ * This component provides a full-featured form for updating user details including
+ * personal information, contact details, and address information.
+ *
+ * Features:
+ * - Editable user profile with avatar display
+ * - Form validation for required fields
+ * - Real-time API updates with loading states
+ * - Success/error feedback notifications
+ * - Nested object state management for complex user data structure
+ */
+
 import * as React from "react";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
@@ -17,60 +32,82 @@ import Alert from "@mui/material/Alert";
 import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 
+/**
+ * User interface matching the structure from the Users API
+ * (https://user-api.builder-io.workers.dev/api/users)
+ *
+ * This interface defines the complete user object structure including:
+ * - Login credentials and identification
+ * - Personal information (name, gender, age)
+ * - Contact information (email, phone, cell)
+ * - Location and address details
+ * - Optional metadata (date of birth, registration, pictures)
+ */
 interface User {
+  // User authentication and identification
   login: {
-    uuid: string;
-    username: string;
-    password: string;
+    uuid: string; // Unique identifier for the user
+    username: string; // Username for login
+    password: string; // Password (hashed in production)
   };
+  // User's full name with title
   name: {
-    title: string;
-    first: string;
-    last: string;
+    title: string; // Title (Mr, Mrs, Ms, Miss, Dr)
+    first: string; // First name
+    last: string; // Last name
   };
-  gender: string;
+  gender: string; // User's gender (male/female)
+  // Complete address and location information
   location: {
     street: {
-      number: number;
-      name: string;
+      number: number; // Street number
+      name: string; // Street name
     };
-    city: string;
-    state: string;
-    country: string;
-    postcode: string;
+    city: string; // City name
+    state: string; // State/province
+    country: string; // Country name
+    postcode: string; // Postal/ZIP code
+    // Optional geographical coordinates
     coordinates?: {
-      latitude: number;
-      longitude: number;
+      latitude: number; // GPS latitude
+      longitude: number; // GPS longitude
     };
+    // Optional timezone information
     timezone?: {
-      offset: string;
-      description: string;
+      offset: string; // UTC offset (e.g., "-05:00")
+      description: string; // Timezone description
     };
   };
-  email: string;
+  email: string; // Primary email address
+  // Optional date of birth information
   dob?: {
-    date: string;
-    age: number;
+    date: string; // Birth date in ISO format
+    age: number; // Calculated age
   };
+  // Optional registration information
   registered?: {
-    date: string;
-    age: number;
+    date: string; // Registration date in ISO format
+    age: number; // Years since registration
   };
-  phone: string;
-  cell?: string;
+  phone: string; // Primary phone number
+  cell?: string; // Optional cell/mobile number
+  // Optional profile pictures in multiple sizes
   picture?: {
-    large: string;
-    medium: string;
-    thumbnail: string;
+    large: string; // URL to large profile picture
+    medium: string; // URL to medium profile picture
+    thumbnail: string; // URL to thumbnail profile picture
   };
-  nat?: string;
+  nat?: string; // Optional nationality code
 }
 
+/**
+ * Props for the EditUserModal component
+ */
 interface EditUserModalProps {
-  open: boolean;
-  user: User;
-  onClose: () => void;
-  onUpdate: (user: User) => Promise<void>;
+  open: boolean; // Controls modal visibility
+  user: User; // The user object to edit
+  onClose: () => void; // Callback when modal is closed
+  onUpdate: (user: User) => Promise<void>; // Callback when user is successfully updated
 }
 
 export default function CrmEditUserModal({

--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -410,7 +410,9 @@ export default function CrmEditUserModal({
             Address
           </Typography>
 
+          {/* Street address - number and name */}
           <Grid container spacing={2}>
+            {/* Street number - smaller field for numeric value */}
             <Grid item xs={12} sm={3}>
               <TextField
                 label="Street Number"
@@ -421,11 +423,13 @@ export default function CrmEditUserModal({
                 onChange={(e) =>
                   handleChange(
                     "location.street.number",
-                    parseInt(e.target.value) || 0,
+                    parseInt(e.target.value) || 0, // Parse to int, default to 0
                   )
                 }
               />
             </Grid>
+
+            {/* Street name - larger field for text */}
             <Grid item xs={12} sm={9}>
               <TextField
                 label="Street Name"
@@ -439,7 +443,9 @@ export default function CrmEditUserModal({
             </Grid>
           </Grid>
 
+          {/* City and state fields */}
           <Grid container spacing={2}>
+            {/* City field */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="City"
@@ -449,6 +455,8 @@ export default function CrmEditUserModal({
                 onChange={(e) => handleChange("location.city", e.target.value)}
               />
             </Grid>
+
+            {/* State/province field */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="State"
@@ -460,7 +468,9 @@ export default function CrmEditUserModal({
             </Grid>
           </Grid>
 
+          {/* Country and postal code fields */}
           <Grid container spacing={2}>
+            {/* Country field */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Country"
@@ -472,6 +482,8 @@ export default function CrmEditUserModal({
                 }
               />
             </Grid>
+
+            {/* Postal/ZIP code field */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Postcode"
@@ -487,15 +499,19 @@ export default function CrmEditUserModal({
         </Stack>
       </DialogContent>
 
+      {/* MODAL FOOTER - Action buttons */}
       <DialogActions>
+        {/* Cancel button - closes modal without saving */}
         <Button onClick={onClose} disabled={loading}>
           Cancel
         </Button>
+
+        {/* Submit button - saves changes and updates user via API */}
         <Button
           type="submit"
           variant="contained"
-          disabled={loading}
-          startIcon={loading ? <CircularProgress size={16} /> : null}
+          disabled={loading} // Disable while submitting
+          startIcon={loading ? <CircularProgress size={16} /> : null} // Show spinner when loading
         >
           {loading ? "Saving..." : "Save Changes"}
         </Button>

--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -110,48 +110,109 @@ interface EditUserModalProps {
   onUpdate: (user: User) => Promise<void>; // Callback when user is successfully updated
 }
 
+/**
+ * Modal component for editing user information
+ */
 export default function CrmEditUserModal({
   open,
   user,
   onClose,
   onUpdate,
 }: EditUserModalProps) {
+  // STATE MANAGEMENT
+  // ----------------
+
+  /**
+   * Form data state - holds the current values of all form fields
+   * Initialized with the user prop and updated as the user edits fields
+   */
   const [formData, setFormData] = React.useState<User>(user);
+
+  /**
+   * Loading state - indicates when the form is submitting to the API
+   * Used to disable form controls and show loading indicators
+   */
   const [loading, setLoading] = React.useState(false);
+
+  /**
+   * Error state - holds any error messages from API calls or validation
+   * Displayed as an alert banner when present
+   */
   const [error, setError] = React.useState<string | null>(null);
+
+  /**
+   * Success state - indicates when a user update was successful
+   * Triggers a success message alert
+   */
   const [success, setSuccess] = React.useState(false);
 
+  /**
+   * Effect to reset form state when the modal opens or user changes
+   * This ensures the form always shows the latest user data and clears
+   * any previous error/success states
+   */
   React.useEffect(() => {
-    setFormData(user);
-    setError(null);
-    setSuccess(false);
+    setFormData(user); // Reset form to current user data
+    setError(null); // Clear any previous errors
+    setSuccess(false); // Clear any previous success messages
   }, [user, open]);
 
+  // EVENT HANDLERS
+  // --------------
+
+  /**
+   * Generic change handler for all form fields
+   * Supports nested object paths using dot notation (e.g., "name.first", "location.city")
+   *
+   * @param field - The field path to update (supports dot notation for nested fields)
+   * @param value - The new value for the field
+   *
+   * Examples:
+   * - handleChange("email", "new@email.com") - updates top-level field
+   * - handleChange("name.first", "John") - updates nested field
+   * - handleChange("location.street.name", "Main St") - updates deeply nested field
+   */
   const handleChange = (field: string, value: any) => {
     setFormData((prev) => {
+      // Split the field path by dots to handle nested objects
       const keys = field.split(".");
+
+      // Handle simple top-level fields
       if (keys.length === 1) {
         return { ...prev, [field]: value };
       }
 
+      // Handle nested fields by creating a new object with updated nested value
       const newData = { ...prev };
       let current: any = newData;
+
+      // Navigate to the parent of the target field, creating copies along the way
+      // This ensures immutability - we don't mutate the original object
       for (let i = 0; i < keys.length - 1; i++) {
-        current[keys[i]] = { ...current[keys[i]] };
-        current = current[keys[i]];
+        current[keys[i]] = { ...current[keys[i]] }; // Clone the nested object
+        current = current[keys[i]]; // Move deeper into the structure
       }
+
+      // Set the final value at the target field
       current[keys[keys.length - 1]] = value;
       return newData;
     });
   };
 
+  /**
+   * Form submission handler
+   * Validates form data, sends PUT request to the API, and handles the response
+   *
+   * @param e - Form event to prevent default browser submission
+   */
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    setError(null);
-    setSuccess(false);
+    e.preventDefault(); // Prevent default form submission behavior
+    setLoading(true); // Show loading state
+    setError(null); // Clear any previous errors
+    setSuccess(false); // Clear any previous success messages
 
     try {
+      // Send PUT request to update the user via the API
       const response = await fetch(
         `https://user-api.builder-io.workers.dev/api/users/${user.login.uuid}`,
         {
@@ -163,19 +224,27 @@ export default function CrmEditUserModal({
         },
       );
 
+      // Handle API errors
       if (!response.ok) {
+        // Try to parse error details from response body
         const errorData = await response.json().catch(() => ({}));
         throw new Error(
           errorData.error || `Failed to update user: ${response.statusText}`,
         );
       }
 
+      // Show success message
       setSuccess(true);
+
+      // Notify parent component of successful update
+      // This typically triggers a refresh of the user list
       await onUpdate(formData);
     } catch (err) {
+      // Handle and display errors
       setError(err instanceof Error ? err.message : "Failed to update user");
       console.error("Error updating user:", err);
     } finally {
+      // Always clear loading state, even if there was an error
       setLoading(false);
     }
   };

--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -1,0 +1,372 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Grid from "@mui/material/Grid";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import Typography from "@mui/material/Typography";
+import Alert from "@mui/material/Alert";
+import CircularProgress from "@mui/material/CircularProgress";
+import Box from "@mui/material/Box";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob?: {
+    date: string;
+    age: number;
+  };
+  registered?: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell?: string;
+  picture?: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat?: string;
+}
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User;
+  onClose: () => void;
+  onUpdate: (user: User) => Promise<void>;
+}
+
+export default function CrmEditUserModal({
+  open,
+  user,
+  onClose,
+  onUpdate,
+}: EditUserModalProps) {
+  const [formData, setFormData] = React.useState<User>(user);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  React.useEffect(() => {
+    setFormData(user);
+    setError(null);
+    setSuccess(false);
+  }, [user, open]);
+
+  const handleChange = (field: string, value: any) => {
+    setFormData((prev) => {
+      const keys = field.split(".");
+      if (keys.length === 1) {
+        return { ...prev, [field]: value };
+      }
+
+      const newData = { ...prev };
+      let current: any = newData;
+      for (let i = 0; i < keys.length - 1; i++) {
+        current[keys[i]] = { ...current[keys[i]] };
+        current = current[keys[i]];
+      }
+      current[keys[keys.length - 1]] = value;
+      return newData;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users/${user.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(formData),
+        },
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error || `Failed to update user: ${response.statusText}`,
+        );
+      }
+
+      setSuccess(true);
+      await onUpdate(formData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update user");
+      console.error("Error updating user:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        component: "form",
+        onSubmit: handleSubmit,
+      }}
+    >
+      <DialogTitle>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar
+            src={user.picture?.large}
+            alt={`${user.name.first} ${user.name.last}`}
+            sx={{ width: 48, height: 48 }}
+          >
+            {user.name.first[0]}
+            {user.name.last[0]}
+          </Avatar>
+          <Box>
+            <Typography variant="h6">Edit User</Typography>
+            <Typography variant="body2" color="text.secondary">
+              @{user.login.username}
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Stack spacing={3}>
+          {error && (
+            <Alert severity="error" onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+          {success && (
+            <Alert severity="success" onClose={() => setSuccess(false)}>
+              User updated successfully!
+            </Alert>
+          )}
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={4}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Title</InputLabel>
+                <Select
+                  value={formData.name.title}
+                  label="Title"
+                  onChange={(e) => handleChange("name.title", e.target.value)}
+                >
+                  <MenuItem value="Mr">Mr</MenuItem>
+                  <MenuItem value="Mrs">Mrs</MenuItem>
+                  <MenuItem value="Ms">Ms</MenuItem>
+                  <MenuItem value="Miss">Miss</MenuItem>
+                  <MenuItem value="Dr">Dr</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="First Name"
+                fullWidth
+                size="small"
+                required
+                value={formData.name.first}
+                onChange={(e) => handleChange("name.first", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="Last Name"
+                fullWidth
+                size="small"
+                required
+                value={formData.name.last}
+                onChange={(e) => handleChange("name.last", e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Email"
+                type="email"
+                fullWidth
+                size="small"
+                required
+                value={formData.email}
+                onChange={(e) => handleChange("email", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Gender</InputLabel>
+                <Select
+                  value={formData.gender}
+                  label="Gender"
+                  onChange={(e) => handleChange("gender", e.target.value)}
+                >
+                  <MenuItem value="male">Male</MenuItem>
+                  <MenuItem value="female">Female</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Phone"
+                fullWidth
+                size="small"
+                value={formData.phone}
+                onChange={(e) => handleChange("phone", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Cell"
+                fullWidth
+                size="small"
+                value={formData.cell || ""}
+                onChange={(e) => handleChange("cell", e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Typography variant="subtitle2" sx={{ mt: 2 }}>
+            Address
+          </Typography>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={3}>
+              <TextField
+                label="Street Number"
+                fullWidth
+                size="small"
+                type="number"
+                value={formData.location.street.number}
+                onChange={(e) =>
+                  handleChange(
+                    "location.street.number",
+                    parseInt(e.target.value) || 0,
+                  )
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={9}>
+              <TextField
+                label="Street Name"
+                fullWidth
+                size="small"
+                value={formData.location.street.name}
+                onChange={(e) =>
+                  handleChange("location.street.name", e.target.value)
+                }
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="City"
+                fullWidth
+                size="small"
+                value={formData.location.city}
+                onChange={(e) => handleChange("location.city", e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="State"
+                fullWidth
+                size="small"
+                value={formData.location.state}
+                onChange={(e) => handleChange("location.state", e.target.value)}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Country"
+                fullWidth
+                size="small"
+                value={formData.location.country}
+                onChange={(e) =>
+                  handleChange("location.country", e.target.value)
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Postcode"
+                fullWidth
+                size="small"
+                value={formData.location.postcode}
+                onChange={(e) =>
+                  handleChange("location.postcode", e.target.value)
+                }
+              />
+            </Grid>
+          </Grid>
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {loading ? "Saving..." : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -302,7 +302,10 @@ export default function CrmEditUserModal({
             </Alert>
           )}
 
+          {/* PERSONAL INFORMATION SECTION */}
+          {/* Name fields - Title, First Name, Last Name */}
           <Grid container spacing={2}>
+            {/* Title selector (Mr, Mrs, Ms, etc.) */}
             <Grid item xs={12} sm={4}>
               <FormControl fullWidth size="small">
                 <InputLabel>Title</InputLabel>
@@ -319,6 +322,8 @@ export default function CrmEditUserModal({
                 </Select>
               </FormControl>
             </Grid>
+
+            {/* First name - required field */}
             <Grid item xs={12} sm={4}>
               <TextField
                 label="First Name"
@@ -329,6 +334,8 @@ export default function CrmEditUserModal({
                 onChange={(e) => handleChange("name.first", e.target.value)}
               />
             </Grid>
+
+            {/* Last name - required field */}
             <Grid item xs={12} sm={4}>
               <TextField
                 label="Last Name"
@@ -341,7 +348,10 @@ export default function CrmEditUserModal({
             </Grid>
           </Grid>
 
+          {/* CONTACT INFORMATION SECTION */}
+          {/* Email and gender fields */}
           <Grid container spacing={2}>
+            {/* Email - required field with email validation */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Email"
@@ -353,6 +363,8 @@ export default function CrmEditUserModal({
                 onChange={(e) => handleChange("email", e.target.value)}
               />
             </Grid>
+
+            {/* Gender selector */}
             <Grid item xs={12} sm={6}>
               <FormControl fullWidth size="small">
                 <InputLabel>Gender</InputLabel>
@@ -368,7 +380,9 @@ export default function CrmEditUserModal({
             </Grid>
           </Grid>
 
+          {/* Phone number fields */}
           <Grid container spacing={2}>
+            {/* Primary phone number */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Phone"
@@ -378,6 +392,8 @@ export default function CrmEditUserModal({
                 onChange={(e) => handleChange("phone", e.target.value)}
               />
             </Grid>
+
+            {/* Secondary/mobile phone number (optional) */}
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Cell"
@@ -389,6 +405,7 @@ export default function CrmEditUserModal({
             </Grid>
           </Grid>
 
+          {/* ADDRESS SECTION HEADER */}
           <Typography variant="subtitle2" sx={{ mt: 2 }}>
             Address
           </Typography>

--- a/src/crm/components/CrmEditUserModal.tsx
+++ b/src/crm/components/CrmEditUserModal.tsx
@@ -249,27 +249,33 @@ export default function CrmEditUserModal({
     }
   };
 
+  // RENDER
+  // ------
   return (
     <Dialog
       open={open}
       onClose={onClose}
-      maxWidth="md"
-      fullWidth
+      maxWidth="md" // Medium-sized modal for comfortable form viewing
+      fullWidth // Take full width up to maxWidth
       PaperProps={{
-        component: "form",
-        onSubmit: handleSubmit,
+        component: "form", // Render the dialog as a form element
+        onSubmit: handleSubmit, // Handle form submission
       }}
     >
+      {/* MODAL HEADER - Shows user avatar and identification */}
       <DialogTitle>
         <Stack direction="row" spacing={2} alignItems="center">
+          {/* User avatar - shows profile picture or initials */}
           <Avatar
             src={user.picture?.large}
             alt={`${user.name.first} ${user.name.last}`}
             sx={{ width: 48, height: 48 }}
           >
+            {/* Fallback to initials if no picture available */}
             {user.name.first[0]}
             {user.name.last[0]}
           </Avatar>
+          {/* User identification */}
           <Box>
             <Typography variant="h6">Edit User</Typography>
             <Typography variant="body2" color="text.secondary">
@@ -279,13 +285,17 @@ export default function CrmEditUserModal({
         </Stack>
       </DialogTitle>
 
+      {/* MODAL CONTENT - Contains all form fields */}
       <DialogContent dividers>
         <Stack spacing={3}>
+          {/* Error alert - shown when API call fails */}
           {error && (
             <Alert severity="error" onClose={() => setError(null)}>
               {error}
             </Alert>
           )}
+
+          {/* Success alert - shown when user is successfully updated */}
           {success && (
             <Alert severity="success" onClose={() => setSuccess(false)}>
               User updated successfully!

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -1,0 +1,337 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import Stack from "@mui/material/Stack";
+import Avatar from "@mui/material/Avatar";
+import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import CrmEditUserModal from "./CrmEditUserModal";
+
+interface User {
+  login: {
+    uuid: string;
+    username: string;
+    password: string;
+  };
+  name: {
+    title: string;
+    first: string;
+    last: string;
+  };
+  gender: string;
+  location: {
+    street: {
+      number: number;
+      name: string;
+    };
+    city: string;
+    state: string;
+    country: string;
+    postcode: string;
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+    timezone?: {
+      offset: string;
+      description: string;
+    };
+  };
+  email: string;
+  dob?: {
+    date: string;
+    age: number;
+  };
+  registered?: {
+    date: string;
+    age: number;
+  };
+  phone: string;
+  cell?: string;
+  picture?: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat?: string;
+}
+
+interface ApiResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  data: User[];
+}
+
+export default function CrmUsersTable() {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [paginationModel, setPaginationModel] = React.useState({
+    page: 0,
+    pageSize: 10,
+  });
+  const [totalRows, setTotalRows] = React.useState(0);
+  const [editModalOpen, setEditModalOpen] = React.useState(false);
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+
+  const fetchUsers = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        page: String(paginationModel.page + 1),
+        perPage: String(paginationModel.pageSize),
+        ...(searchQuery && { search: searchQuery }),
+      });
+
+      const response = await fetch(
+        `https://user-api.builder-io.workers.dev/api/users?${params}`,
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch users: ${response.statusText}`);
+      }
+
+      const data: ApiResponse = await response.json();
+      setUsers(data.data);
+      setTotalRows(data.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch users");
+      console.error("Error fetching users:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [paginationModel.page, paginationModel.pageSize, searchQuery]);
+
+  React.useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+    setPaginationModel({ ...paginationModel, page: 0 });
+  };
+
+  const handleEditClick = (user: User) => {
+    setSelectedUser(user);
+    setEditModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setEditModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleUserUpdate = async (updatedUser: User) => {
+    await fetchUsers();
+    handleModalClose();
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "avatar",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      filterable: false,
+      renderCell: (params: GridRenderCellParams<User>) => (
+        <Avatar
+          src={params.row.picture?.thumbnail}
+          alt={`${params.row.name.first} ${params.row.name.last}`}
+          sx={{ width: 36, height: 36 }}
+        >
+          {params.row.name.first[0]}
+          {params.row.name.last[0]}
+        </Avatar>
+      ),
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (value, row) =>
+        `${row.name.title} ${row.name.first} ${row.name.last}`,
+      renderCell: (params: GridRenderCellParams<User>) => (
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            {params.row.name.first} {params.row.name.last}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            @{params.row.login.username}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      flex: 1,
+      minWidth: 220,
+    },
+    {
+      field: "location",
+      headerName: "Location",
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (value, row) =>
+        `${row.location.city}, ${row.location.country}`,
+      renderCell: (params: GridRenderCellParams<User>) => (
+        <Box>
+          <Typography variant="body2">
+            {params.row.location.city}, {params.row.location.state}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {params.row.location.country}
+          </Typography>
+        </Box>
+      ),
+    },
+    {
+      field: "phone",
+      headerName: "Phone",
+      width: 140,
+    },
+    {
+      field: "gender",
+      headerName: "Gender",
+      width: 100,
+      renderCell: (params: GridRenderCellParams<User>) => (
+        <Chip
+          label={params.row.gender}
+          size="small"
+          color={params.row.gender === "male" ? "primary" : "secondary"}
+          variant="outlined"
+        />
+      ),
+    },
+    {
+      field: "age",
+      headerName: "Age",
+      width: 80,
+      align: "center",
+      headerAlign: "center",
+      valueGetter: (value, row) => row.dob?.age || "N/A",
+    },
+    {
+      field: "actions",
+      headerName: "Actions",
+      width: 90,
+      align: "center",
+      headerAlign: "center",
+      sortable: false,
+      filterable: false,
+      renderCell: (params: GridRenderCellParams<User>) => (
+        <IconButton
+          size="small"
+          color="primary"
+          onClick={() => handleEditClick(params.row)}
+          aria-label={`Edit ${params.row.name.first} ${params.row.name.last}`}
+        >
+          <EditRoundedIcon fontSize="small" />
+        </IconButton>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Card variant="outlined" sx={{ height: "100%" }}>
+        <CardContent>
+          <Stack spacing={2}>
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              spacing={2}
+            >
+              <Typography variant="h6" component="h3">
+                Users
+              </Typography>
+            </Stack>
+
+            <TextField
+              placeholder="Search users by name, email, or city..."
+              variant="outlined"
+              size="small"
+              fullWidth
+              value={searchQuery}
+              onChange={handleSearchChange}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchRoundedIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            {error ? (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {error}
+              </Alert>
+            ) : null}
+
+            <Box sx={{ height: 600, width: "100%" }}>
+              <DataGrid
+                rows={users}
+                columns={columns}
+                getRowId={(row) => row.login.uuid}
+                loading={loading}
+                paginationMode="server"
+                paginationModel={paginationModel}
+                onPaginationModelChange={setPaginationModel}
+                pageSizeOptions={[5, 10, 25, 50]}
+                rowCount={totalRows}
+                disableRowSelectionOnClick
+                sx={{
+                  border: "none",
+                  "& .MuiDataGrid-cell:focus": {
+                    outline: "none",
+                  },
+                  "& .MuiDataGrid-cell:focus-within": {
+                    outline: "none",
+                  },
+                }}
+                slots={{
+                  loadingOverlay: () => (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        height: "100%",
+                      }}
+                    >
+                      <CircularProgress />
+                    </Box>
+                  ),
+                }}
+              />
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {selectedUser && (
+        <CrmEditUserModal
+          open={editModalOpen}
+          user={selectedUser}
+          onClose={handleModalClose}
+          onUpdate={handleUserUpdate}
+        />
+      )}
+    </>
+  );
+}

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -100,70 +100,152 @@ interface ApiResponse {
   data: User[]; // Array of user objects
 }
 
+/**
+ * Main users table component
+ */
 export default function CrmUsersTable() {
+  // STATE MANAGEMENT
+  // ----------------
+
+  /**
+   * Users array - holds the current page of user data from the API
+   */
   const [users, setUsers] = React.useState<User[]>([]);
+
+  /**
+   * Loading state - indicates when data is being fetched from the API
+   * Used to show loading indicators and disable interactions
+   */
   const [loading, setLoading] = React.useState(true);
+
+  /**
+   * Error state - holds any error messages from API calls
+   * Displayed as an alert banner when present
+   */
   const [error, setError] = React.useState<string | null>(null);
+
+  /**
+   * Search query state - holds the current search filter text
+   * Filters users by name, email, or city
+   */
   const [searchQuery, setSearchQuery] = React.useState("");
+
+  /**
+   * Pagination model - controls current page and items per page
+   * Note: API uses 1-based page numbers, but DataGrid uses 0-based
+   */
   const [paginationModel, setPaginationModel] = React.useState({
-    page: 0,
-    pageSize: 10,
+    page: 0, // Current page (0-indexed for DataGrid)
+    pageSize: 10, // Number of items per page
   });
+
+  /**
+   * Total row count - total number of users in the database
+   * Used for pagination to show correct number of pages
+   */
   const [totalRows, setTotalRows] = React.useState(0);
+
+  /**
+   * Edit modal visibility state
+   */
   const [editModalOpen, setEditModalOpen] = React.useState(false);
+
+  /**
+   * Selected user for editing
+   * Null when no user is selected
+   */
   const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
 
+  // API FUNCTIONS
+  // -------------
+
+  /**
+   * Fetches users from the API with current pagination and search parameters
+   * Uses useCallback to memoize the function and prevent unnecessary re-renders
+   * Dependencies: page, pageSize, searchQuery
+   */
   const fetchUsers = React.useCallback(async () => {
     setLoading(true);
     setError(null);
+
     try {
+      // Build query parameters for the API request
+      // Note: API uses 1-based page numbers, so we add 1 to the page
       const params = new URLSearchParams({
-        page: String(paginationModel.page + 1),
+        page: String(paginationModel.page + 1), // Convert to 1-based
         perPage: String(paginationModel.pageSize),
-        ...(searchQuery && { search: searchQuery }),
+        ...(searchQuery && { search: searchQuery }), // Only include search if not empty
       });
 
+      // Fetch users from the API
       const response = await fetch(
         `https://user-api.builder-io.workers.dev/api/users?${params}`,
       );
 
+      // Handle API errors
       if (!response.ok) {
         throw new Error(`Failed to fetch users: ${response.statusText}`);
       }
 
+      // Parse and store the response data
       const data: ApiResponse = await response.json();
-      setUsers(data.data);
-      setTotalRows(data.total);
+      setUsers(data.data); // Update users array
+      setTotalRows(data.total); // Update total count for pagination
     } catch (err) {
+      // Handle and display errors
       setError(err instanceof Error ? err.message : "Failed to fetch users");
       console.error("Error fetching users:", err);
     } finally {
+      // Always clear loading state, even if there was an error
       setLoading(false);
     }
   }, [paginationModel.page, paginationModel.pageSize, searchQuery]);
 
+  /**
+   * Effect to fetch users whenever pagination or search changes
+   * Runs on component mount and when fetchUsers dependencies change
+   */
   React.useEffect(() => {
     fetchUsers();
   }, [fetchUsers]);
 
+  // EVENT HANDLERS
+  // --------------
+
+  /**
+   * Handles search input changes
+   * Resets to page 0 when search query changes to show results from the beginning
+   */
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
-    setPaginationModel({ ...paginationModel, page: 0 });
+    setPaginationModel({ ...paginationModel, page: 0 }); // Reset to first page
   };
 
+  /**
+   * Opens the edit modal for a specific user
+   * @param user - The user to edit
+   */
   const handleEditClick = (user: User) => {
     setSelectedUser(user);
     setEditModalOpen(true);
   };
 
+  /**
+   * Closes the edit modal and clears the selected user
+   */
   const handleModalClose = () => {
     setEditModalOpen(false);
     setSelectedUser(null);
   };
 
+  /**
+   * Handles successful user update from the modal
+   * Refreshes the user list and closes the modal
+   * @param updatedUser - The updated user data (not currently used but available)
+   */
   const handleUserUpdate = async (updatedUser: User) => {
-    await fetchUsers();
-    handleModalClose();
+    await fetchUsers(); // Refresh the table data
+    handleModalClose(); // Close the modal
   };
 
   const columns: GridColDef[] = [

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -1,3 +1,23 @@
+/**
+ * CRM Users Table Component
+ *
+ * A comprehensive data table for displaying and managing users in the CRM system.
+ * This component integrates with the Users API and provides full CRUD functionality.
+ *
+ * Features:
+ * - Server-side pagination for efficient data handling
+ * - Real-time search across multiple fields (name, email, city)
+ * - Inline edit functionality via modal dialog
+ * - Responsive DataGrid with sortable columns
+ * - Loading and error states
+ * - User avatars and formatted data display
+ *
+ * API Integration:
+ * - Fetches data from https://user-api.builder-io.workers.dev/api/users
+ * - Supports query parameters: page, perPage, search
+ * - Updates user data via PUT requests
+ */
+
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
@@ -16,60 +36,68 @@ import Alert from "@mui/material/Alert";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import CrmEditUserModal from "./CrmEditUserModal";
 
+/**
+ * User interface matching the structure from the Users API
+ * Represents a complete user record with all associated data
+ */
 interface User {
   login: {
-    uuid: string;
-    username: string;
-    password: string;
+    uuid: string; // Unique identifier
+    username: string; // Login username
+    password: string; // User password
   };
   name: {
-    title: string;
-    first: string;
-    last: string;
+    title: string; // Honorific (Mr, Mrs, Ms, etc.)
+    first: string; // First name
+    last: string; // Last name
   };
-  gender: string;
+  gender: string; // Gender (male/female)
   location: {
     street: {
-      number: number;
-      name: string;
+      number: number; // Street number
+      name: string; // Street name
     };
-    city: string;
-    state: string;
-    country: string;
-    postcode: string;
+    city: string; // City
+    state: string; // State/province
+    country: string; // Country
+    postcode: string; // Postal code
     coordinates?: {
-      latitude: number;
-      longitude: number;
+      latitude: number; // GPS latitude
+      longitude: number; // GPS longitude
     };
     timezone?: {
-      offset: string;
-      description: string;
+      offset: string; // UTC offset
+      description: string; // Timezone name
     };
   };
-  email: string;
+  email: string; // Email address
   dob?: {
-    date: string;
-    age: number;
+    date: string; // Date of birth
+    age: number; // Calculated age
   };
   registered?: {
-    date: string;
-    age: number;
+    date: string; // Registration date
+    age: number; // Years since registration
   };
-  phone: string;
-  cell?: string;
+  phone: string; // Primary phone
+  cell?: string; // Cell/mobile phone
   picture?: {
-    large: string;
-    medium: string;
-    thumbnail: string;
+    large: string; // Large profile picture URL
+    medium: string; // Medium profile picture URL
+    thumbnail: string; // Thumbnail profile picture URL
   };
-  nat?: string;
+  nat?: string; // Nationality code
 }
 
+/**
+ * API Response interface for the Users API
+ * Contains pagination metadata and user data array
+ */
 interface ApiResponse {
-  page: number;
-  perPage: number;
-  total: number;
-  data: User[];
+  page: number; // Current page number
+  perPage: number; // Items per page
+  total: number; // Total number of users
+  data: User[]; // Array of user objects
 }
 
 export default function CrmUsersTable() {

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -248,7 +248,17 @@ export default function CrmUsersTable() {
     handleModalClose(); // Close the modal
   };
 
+  // COLUMN DEFINITIONS
+  // ------------------
+  /**
+   * DataGrid column configuration
+   * Defines how each column is displayed, sorted, and filtered
+   */
   const columns: GridColDef[] = [
+    /**
+     * Avatar column - displays user profile picture or initials
+     * Not sortable or filterable since it's just visual
+     */
     {
       field: "avatar",
       headerName: "",
@@ -261,15 +271,21 @@ export default function CrmUsersTable() {
           alt={`${params.row.name.first} ${params.row.name.last}`}
           sx={{ width: 36, height: 36 }}
         >
+          {/* Fallback to initials if no picture */}
           {params.row.name.first[0]}
           {params.row.name.last[0]}
         </Avatar>
       ),
     },
+    /**
+     * Name column - displays full name with username
+     * Shows name in bold and username as secondary text
+     * valueGetter is used for sorting/filtering the combined name
+     */
     {
       field: "name",
       headerName: "Name",
-      flex: 1,
+      flex: 1, // Flexible width
       minWidth: 180,
       valueGetter: (value, row) =>
         `${row.name.title} ${row.name.first} ${row.name.last}`,
@@ -284,12 +300,21 @@ export default function CrmUsersTable() {
         </Box>
       ),
     },
+    /**
+     * Email column - displays user's email address
+     * Simple text display with default sorting
+     */
     {
       field: "email",
       headerName: "Email",
       flex: 1,
       minWidth: 220,
     },
+    /**
+     * Location column - displays city, state, and country
+     * Shows city/state in primary text and country in secondary
+     * valueGetter combines city and country for sorting/filtering
+     */
     {
       field: "location",
       headerName: "Location",

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -485,12 +485,13 @@ export default function CrmUsersTable() {
         </CardContent>
       </Card>
 
+      {/* Edit User Modal - only rendered when a user is selected for editing */}
       {selectedUser && (
         <CrmEditUserModal
-          open={editModalOpen}
-          user={selectedUser}
-          onClose={handleModalClose}
-          onUpdate={handleUserUpdate}
+          open={editModalOpen} // Controls modal visibility
+          user={selectedUser} // The user being edited
+          onClose={handleModalClose} // Handle modal close
+          onUpdate={handleUserUpdate} // Handle successful update
         />
       )}
     </>

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -333,11 +333,19 @@ export default function CrmUsersTable() {
         </Box>
       ),
     },
+    /**
+     * Phone column - displays primary phone number
+     * Simple text display
+     */
     {
       field: "phone",
       headerName: "Phone",
       width: 140,
     },
+    /**
+     * Gender column - displays gender with color-coded chip
+     * Male = primary (blue), Female = secondary (purple/pink)
+     */
     {
       field: "gender",
       headerName: "Gender",
@@ -351,6 +359,10 @@ export default function CrmUsersTable() {
         />
       ),
     },
+    /**
+     * Age column - displays user's age from date of birth
+     * Center-aligned, shows "N/A" if age data is not available
+     */
     {
       field: "age",
       headerName: "Age",
@@ -359,6 +371,11 @@ export default function CrmUsersTable() {
       headerAlign: "center",
       valueGetter: (value, row) => row.dob?.age || "N/A",
     },
+    /**
+     * Actions column - displays edit button for each user
+     * Not sortable or filterable
+     * Triggers the edit modal when clicked
+     */
     {
       field: "actions",
       headerName: "Actions",

--- a/src/crm/components/CrmUsersTable.tsx
+++ b/src/crm/components/CrmUsersTable.tsx
@@ -397,11 +397,15 @@ export default function CrmUsersTable() {
     },
   ];
 
+  // RENDER
+  // ------
   return (
     <>
+      {/* Main card container */}
       <Card variant="outlined" sx={{ height: "100%" }}>
         <CardContent>
           <Stack spacing={2}>
+            {/* Header section with title */}
             <Stack
               direction="row"
               justifyContent="space-between"
@@ -413,6 +417,7 @@ export default function CrmUsersTable() {
               </Typography>
             </Stack>
 
+            {/* Search input field */}
             <TextField
               placeholder="Search users by name, email, or city..."
               variant="outlined"
@@ -429,26 +434,29 @@ export default function CrmUsersTable() {
               }}
             />
 
+            {/* Error alert - shown when API call fails */}
             {error ? (
               <Alert severity="error" sx={{ mb: 2 }}>
                 {error}
               </Alert>
             ) : null}
 
+            {/* DataGrid container */}
             <Box sx={{ height: 600, width: "100%" }}>
               <DataGrid
-                rows={users}
-                columns={columns}
-                getRowId={(row) => row.login.uuid}
-                loading={loading}
-                paginationMode="server"
-                paginationModel={paginationModel}
-                onPaginationModelChange={setPaginationModel}
-                pageSizeOptions={[5, 10, 25, 50]}
-                rowCount={totalRows}
-                disableRowSelectionOnClick
+                rows={users} // User data array
+                columns={columns} // Column definitions
+                getRowId={(row) => row.login.uuid} // Use UUID as unique row identifier
+                loading={loading} // Show loading state
+                paginationMode="server" // Enable server-side pagination
+                paginationModel={paginationModel} // Current page and page size
+                onPaginationModelChange={setPaginationModel} // Handle pagination changes
+                pageSizeOptions={[5, 10, 25, 50]} // Available page size options
+                rowCount={totalRows} // Total number of rows for pagination
+                disableRowSelectionOnClick // Don't select rows on click
                 sx={{
                   border: "none",
+                  // Remove focus outline from cells
                   "& .MuiDataGrid-cell:focus": {
                     outline: "none",
                   },
@@ -457,6 +465,7 @@ export default function CrmUsersTable() {
                   },
                 }}
                 slots={{
+                  // Custom loading overlay with centered spinner
                   loadingOverlay: () => (
                     <Box
                       sx={{

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,19 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CrmUsersTable from "../components/CrmUsersTable";
 
 export default function Customers() {
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
+      <Typography paragraph color="text.secondary" sx={{ mb: 3 }}>
+        View and manage your customer data. Search, edit, and track all customer
+        information in one place.
       </Typography>
+      <CrmUsersTable />
     </Box>
   );
 }


### PR DESCRIPTION
**Summary**
This PR implements a full-featured users table on the Customers page, including server-side search, pagination, and an edit modal for updating user details via an external API.

**Problem**
The Customers page was previously a placeholder with static text. There was a need to display actual customer data, allow searching through users, and provide a way to edit user information directly from the UI.

**Solution**
I created two new components: `CrmUsersTable` for displaying data using MUI DataGrid and `CrmEditUserModal` for handling updates. The table fetches data dynamically based on search and pagination state, while the modal handles form submission to the users API.

**Key Changes**
- Added `CrmUsersTable` component with server-side pagination and search functionality.
- Created `CrmEditUserModal` component with a multi-field form (Name, Email, Address, etc.) for editing users.
- integrated the users table into the main `Customers` page.
- Implemented API integration for fetching (`GET`) and updating (`PUT`) user data.

**Files Changed**
- `src/crm/components/CrmEditUserModal.tsx`: Created new file for the user editing dialog form.
- `src/crm/components/CrmUsersTable.tsx`: Created new file (implied) containing the DataGrid and data fetching logic.
- `src/crm/pages/Customers.tsx`: Updated to render the `CrmUsersTable` component instead of placeholder text.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/732f251a2f7347b08695f539bfd6f8a7/quantum-studio)

👀 [Preview Link](https://732f251a2f7347b08695f539bfd6f8a7-quantum-studio.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>732f251a2f7347b08695f539bfd6f8a7</projectId>-->
<!--<branchName>quantum-studio</branchName>-->