### PR TITLE
Add users table with search and edit modal

### DIFF
--- a/src/crm/components/CustomersUsersTable.tsx
+++ b/src/crm/components/CustomersUsersTable.tsx
@@ -14,8 +14,16 @@ import InputAdornment from "@mui/material/InputAdornment";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import EditUserModal from "./EditUserModal";
 
+/**
+ * Base URL for the Users API
+ * This API provides CRUD operations for user management
+ */
 const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
 
+/**
+ * Interface representing a user's physical location
+ * Contains address details including street, city, state, country, and postal code
+ */
 interface UserLocation {
   street: {
     number: number;
@@ -27,17 +35,29 @@ interface UserLocation {
   postcode: string;
 }
 
+/**
+ * Interface representing a user's name components
+ * Includes title (Mr, Mrs, etc.), first name, and last name
+ */
 interface UserName {
   title: string;
   first: string;
   last: string;
 }
 
+/**
+ * Interface representing user login credentials
+ * Contains unique identifier (UUID) and username
+ */
 interface UserLogin {
   uuid: string;
   username: string;
 }
 
+/**
+ * Main User interface representing a complete user object
+ * Contains all user information including personal details, contact info, and location
+ */
 interface User {
   login: UserLogin;
   name: UserName;
@@ -62,6 +82,10 @@ interface User {
   nat: string;
 }
 
+/**
+ * Interface representing the API response structure
+ * Contains paginated user data along with metadata
+ */
 interface ApiResponse {
   data: User[];
   total: number;
@@ -69,71 +93,144 @@ interface ApiResponse {
   perPage: number;
 }
 
+/**
+ * CustomersUsersTable Component
+ * 
+ * A comprehensive table component for displaying and managing user data.
+ * Features include:
+ * - Server-side pagination for efficient data loading
+ * - Real-time search functionality (searches name, email, city)
+ * - Inline edit capability via modal dialog
+ * - Responsive data grid with customizable columns
+ * 
+ * @returns A Material-UI Card containing a searchable, paginated user table
+ */
 export default function CustomersUsersTable() {
+  // State management for users data fetched from API
   const [users, setUsers] = React.useState<User[]>([]);
+  
+  // Loading state to show spinner while fetching data
   const [loading, setLoading] = React.useState(true);
+  
+  // Search query state - triggers debounced API call when changed
   const [searchQuery, setSearchQuery] = React.useState("");
+  
+  // Total number of users in database (for pagination)
   const [totalRows, setTotalRows] = React.useState(0);
+  
+  // Pagination state - tracks current page and items per page
+  // Note: DataGrid uses 0-based page index, but API uses 1-based
   const [paginationModel, setPaginationModel] = React.useState({
     page: 0,
     pageSize: 10,
   });
+  
+  // State for managing the edit modal
   const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
 
+  /**
+   * Fetches users from the API with current pagination and search parameters
+   * 
+   * This function:
+   * 1. Constructs query parameters from current state
+   * 2. Makes GET request to users API
+   * 3. Updates users and total count in state
+   * 4. Handles errors gracefully by resetting to empty state
+   * 
+   * Dependencies: paginationModel.page, paginationModel.pageSize, searchQuery
+   */
   const fetchUsers = React.useCallback(async () => {
     setLoading(true);
     try {
+      // Build query parameters for API request
+      // Convert 0-based page to 1-based for API
       const params = new URLSearchParams({
         page: String(paginationModel.page + 1),
         perPage: String(paginationModel.pageSize),
+        // Only include search parameter if query is not empty
         ...(searchQuery && { search: searchQuery }),
       });
 
+      // Fetch users from API
       const response = await fetch(`${API_BASE_URL}/users?${params}`);
       const data: ApiResponse = await response.json();
       
+      // Update state with fetched data
       setUsers(data.data || []);
       setTotalRows(data.total || 0);
     } catch (error) {
+      // Log error and reset to empty state on failure
       console.error("Error fetching users:", error);
       setUsers([]);
       setTotalRows(0);
     } finally {
+      // Always stop loading spinner, regardless of success/failure
       setLoading(false);
     }
   }, [paginationModel.page, paginationModel.pageSize, searchQuery]);
 
+  /**
+   * Effect hook to trigger user fetching with debouncing
+   * 
+   * Implements a 300ms debounce to prevent excessive API calls
+   * when user types in search field. This improves performance
+   * and reduces server load.
+   * 
+   * The cleanup function cancels pending API calls if dependencies
+   * change before the timeout completes.
+   */
   React.useEffect(() => {
+    // Debounce API calls by 300ms
     const timer = setTimeout(() => {
       fetchUsers();
     }, 300);
 
+    // Cleanup: cancel pending API call if dependencies change
     return () => clearTimeout(timer);
   }, [fetchUsers]);
 
+  /**
+   * Opens the edit modal with the selected user's data
+   * 
+   * @param user - The user object to edit
+   */
   const handleEditClick = (user: User) => {
     setSelectedUser(user);
     setIsEditModalOpen(true);
   };
 
+  /**
+   * Closes the edit modal and clears selected user
+   */
   const handleCloseModal = () => {
     setIsEditModalOpen(false);
     setSelectedUser(null);
   };
 
+  /**
+   * Handles successful user update from the modal
+   * Refreshes the table data and closes the modal
+   * 
+   * @param updatedUser - The updated user object (currently unused but available for optimistic updates)
+   */
   const handleSaveUser = async (updatedUser: User) => {
-    // Refresh the table after saving
+    // Refresh the table to show updated data from server
     await fetchUsers();
     handleCloseModal();
   };
 
+  /**
+   * Column definitions for the DataGrid
+   * Each column specifies how to display and format user data
+   */
   const columns: GridColDef[] = [
     {
       field: "avatar",
       headerName: "",
       width: 60,
       sortable: false,
+      // Custom render: Display user's profile picture or initials
       renderCell: (params: GridRenderCellParams) => (
         <Avatar
           src={params.row.picture?.thumbnail}
@@ -150,6 +247,7 @@ export default function CustomersUsersTable() {
       headerName: "Name",
       flex: 1,
       minWidth: 180,
+      // Combine title, first, and last name into single display value
       valueGetter: (value, row) =>
         `${row.name?.title || ""} ${row.name?.first || ""} ${row.name?.last || ""}`.trim(),
     },
@@ -164,6 +262,7 @@ export default function CustomersUsersTable() {
       headerName: "Location",
       flex: 1,
       minWidth: 180,
+      // Display city and country as "City, Country"
       valueGetter: (value, row) =>
         `${row.location?.city || ""}, ${row.location?.country || ""}`,
     },
@@ -177,6 +276,7 @@ export default function CustomersUsersTable() {
       field: "gender",
       headerName: "Gender",
       width: 100,
+      // Custom render: Display gender as a colored chip badge
       renderCell: (params: GridRenderCellParams) => (
         <Chip
           label={params.value}
@@ -190,6 +290,7 @@ export default function CustomersUsersTable() {
       field: "age",
       headerName: "Age",
       width: 80,
+      // Extract age from date of birth object
       valueGetter: (value, row) => row.dob?.age || "-",
     },
     {
@@ -197,6 +298,7 @@ export default function CustomersUsersTable() {
       headerName: "Actions",
       width: 100,
       sortable: false,
+      // Custom render: Display edit button for each row
       renderCell: (params: GridRenderCellParams) => (
         <IconButton
           size="small"
@@ -211,9 +313,11 @@ export default function CustomersUsersTable() {
 
   return (
     <>
+      {/* Main card container for the users table */}
       <Card variant="outlined" sx={{ height: "100%" }}>
         <CardContent>
           <Stack spacing={3}>
+            {/* Header section with title */}
             <Stack
               direction="row"
               justifyContent="space-between"
@@ -225,6 +329,8 @@ export default function CustomersUsersTable() {
               </Typography>
             </Stack>
 
+            {/* Search input field with icon
+                Triggers debounced API call when user types */}
             <TextField
               placeholder="Search by name, email, or city..."
               value={searchQuery}
@@ -240,21 +346,23 @@ export default function CustomersUsersTable() {
               }}
             />
 
+            {/* DataGrid container with fixed height for scrolling */}
             <Box sx={{ height: 600, width: "100%" }}>
               <DataGrid
                 rows={users}
                 columns={columns}
                 loading={loading}
                 pagination
-                paginationMode="server"
+                paginationMode="server" // Server-side pagination for better performance
                 rowCount={totalRows}
                 paginationModel={paginationModel}
                 onPaginationModelChange={setPaginationModel}
                 pageSizeOptions={[5, 10, 25, 50]}
-                getRowId={(row) => row.login?.uuid || row.email}
+                getRowId={(row) => row.login?.uuid || row.email} // Use UUID as unique row identifier
                 disableRowSelectionOnClick
                 sx={{
                   border: 0,
+                  // Remove focus outline for cleaner UI
                   "& .MuiDataGrid-cell:focus": {
                     outline: "none",
                   },
@@ -268,6 +376,8 @@ export default function CustomersUsersTable() {
         </CardContent>
       </Card>
 
+      {/* Edit user modal dialog
+          Opens when user clicks edit button on any row */}
       <EditUserModal
         open={isEditModalOpen}
         user={selectedUser}

--- a/src/crm/components/CustomersUsersTable.tsx
+++ b/src/crm/components/CustomersUsersTable.tsx
@@ -1,0 +1,279 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Chip from "@mui/material/Chip";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import InputAdornment from "@mui/material/InputAdornment";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import EditUserModal from "./EditUserModal";
+
+const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
+
+interface UserLocation {
+  street: {
+    number: number;
+    name: string;
+  };
+  city: string;
+  state: string;
+  country: string;
+  postcode: string;
+}
+
+interface UserName {
+  title: string;
+  first: string;
+  last: string;
+}
+
+interface UserLogin {
+  uuid: string;
+  username: string;
+}
+
+interface User {
+  login: UserLogin;
+  name: UserName;
+  email: string;
+  phone: string;
+  cell: string;
+  gender: string;
+  location: UserLocation;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+interface ApiResponse {
+  data: User[];
+  total: number;
+  page: number;
+  perPage: number;
+}
+
+export default function CustomersUsersTable() {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [totalRows, setTotalRows] = React.useState(0);
+  const [paginationModel, setPaginationModel] = React.useState({
+    page: 0,
+    pageSize: 10,
+  });
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+  const [isEditModalOpen, setIsEditModalOpen] = React.useState(false);
+
+  const fetchUsers = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(paginationModel.page + 1),
+        perPage: String(paginationModel.pageSize),
+        ...(searchQuery && { search: searchQuery }),
+      });
+
+      const response = await fetch(`${API_BASE_URL}/users?${params}`);
+      const data: ApiResponse = await response.json();
+      
+      setUsers(data.data || []);
+      setTotalRows(data.total || 0);
+    } catch (error) {
+      console.error("Error fetching users:", error);
+      setUsers([]);
+      setTotalRows(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [paginationModel.page, paginationModel.pageSize, searchQuery]);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchUsers();
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [fetchUsers]);
+
+  const handleEditClick = (user: User) => {
+    setSelectedUser(user);
+    setIsEditModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsEditModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleSaveUser = async (updatedUser: User) => {
+    // Refresh the table after saving
+    await fetchUsers();
+    handleCloseModal();
+  };
+
+  const columns: GridColDef[] = [
+    {
+      field: "avatar",
+      headerName: "",
+      width: 60,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams) => (
+        <Avatar
+          src={params.row.picture?.thumbnail}
+          alt={`${params.row.name?.first} ${params.row.name?.last}`}
+          sx={{ width: 36, height: 36 }}
+        >
+          {params.row.name?.first?.[0]}
+          {params.row.name?.last?.[0]}
+        </Avatar>
+      ),
+    },
+    {
+      field: "name",
+      headerName: "Name",
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (value, row) =>
+        `${row.name?.title || ""} ${row.name?.first || ""} ${row.name?.last || ""}`.trim(),
+    },
+    {
+      field: "email",
+      headerName: "Email",
+      flex: 1,
+      minWidth: 200,
+    },
+    {
+      field: "location",
+      headerName: "Location",
+      flex: 1,
+      minWidth: 180,
+      valueGetter: (value, row) =>
+        `${row.location?.city || ""}, ${row.location?.country || ""}`,
+    },
+    {
+      field: "phone",
+      headerName: "Phone",
+      flex: 1,
+      minWidth: 140,
+    },
+    {
+      field: "gender",
+      headerName: "Gender",
+      width: 100,
+      renderCell: (params: GridRenderCellParams) => (
+        <Chip
+          label={params.value}
+          size="small"
+          color={params.value === "male" ? "primary" : "secondary"}
+          variant="outlined"
+        />
+      ),
+    },
+    {
+      field: "age",
+      headerName: "Age",
+      width: 80,
+      valueGetter: (value, row) => row.dob?.age || "-",
+    },
+    {
+      field: "actions",
+      headerName: "Actions",
+      width: 100,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams) => (
+        <IconButton
+          size="small"
+          onClick={() => handleEditClick(params.row)}
+          aria-label="edit user"
+        >
+          <EditRoundedIcon fontSize="small" />
+        </IconButton>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Card variant="outlined" sx={{ height: "100%" }}>
+        <CardContent>
+          <Stack spacing={3}>
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              spacing={2}
+            >
+              <Typography variant="h6" component="h2">
+                Users
+              </Typography>
+            </Stack>
+
+            <TextField
+              placeholder="Search by name, email, or city..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              size="small"
+              fullWidth
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchRoundedIcon />
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            <Box sx={{ height: 600, width: "100%" }}>
+              <DataGrid
+                rows={users}
+                columns={columns}
+                loading={loading}
+                pagination
+                paginationMode="server"
+                rowCount={totalRows}
+                paginationModel={paginationModel}
+                onPaginationModelChange={setPaginationModel}
+                pageSizeOptions={[5, 10, 25, 50]}
+                getRowId={(row) => row.login?.uuid || row.email}
+                disableRowSelectionOnClick
+                sx={{
+                  border: 0,
+                  "& .MuiDataGrid-cell:focus": {
+                    outline: "none",
+                  },
+                  "& .MuiDataGrid-cell:focus-within": {
+                    outline: "none",
+                  },
+                }}
+              />
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <EditUserModal
+        open={isEditModalOpen}
+        user={selectedUser}
+        onClose={handleCloseModal}
+        onSave={handleSaveUser}
+      />
+    </>
+  );
+}

--- a/src/crm/components/EditUserModal.tsx
+++ b/src/crm/components/EditUserModal.tsx
@@ -1,0 +1,330 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Stack from "@mui/material/Stack";
+import Grid from "@mui/material/Grid";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+
+const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
+
+interface UserLocation {
+  street: {
+    number: number;
+    name: string;
+  };
+  city: string;
+  state: string;
+  country: string;
+  postcode: string;
+}
+
+interface UserName {
+  title: string;
+  first: string;
+  last: string;
+}
+
+interface UserLogin {
+  uuid: string;
+  username: string;
+}
+
+interface User {
+  login: UserLogin;
+  name: UserName;
+  email: string;
+  phone: string;
+  cell: string;
+  gender: string;
+  location: UserLocation;
+  dob: {
+    date: string;
+    age: number;
+  };
+  registered: {
+    date: string;
+    age: number;
+  };
+  picture: {
+    large: string;
+    medium: string;
+    thumbnail: string;
+  };
+  nat: string;
+}
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onSave: (user: User) => void;
+}
+
+export default function EditUserModal({
+  open,
+  user,
+  onClose,
+  onSave,
+}: EditUserModalProps) {
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [formData, setFormData] = React.useState<Partial<User>>({});
+
+  React.useEffect(() => {
+    if (user) {
+      setFormData(user);
+      setError(null);
+    }
+  }, [user]);
+
+  const handleChange = (field: string, value: any) => {
+    setFormData((prev) => {
+      const keys = field.split(".");
+      if (keys.length === 1) {
+        return { ...prev, [field]: value };
+      }
+
+      // Handle nested fields like "name.first" or "location.city"
+      const newData = { ...prev };
+      let current: any = newData;
+      for (let i = 0; i < keys.length - 1; i++) {
+        if (!current[keys[i]]) {
+          current[keys[i]] = {};
+        } else {
+          current[keys[i]] = { ...current[keys[i]] };
+        }
+        current = current[keys[i]];
+      }
+      current[keys[keys.length - 1]] = value;
+      return newData;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `${API_BASE_URL}/users/${user.login.uuid}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(formData),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update user");
+      }
+
+      onSave(formData as User);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update user");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        component: "form",
+        onSubmit: handleSubmit,
+      }}
+    >
+      <DialogTitle>Edit User</DialogTitle>
+      <DialogContent>
+        <Stack spacing={3} sx={{ mt: 2 }}>
+          {error && (
+            <Alert severity="error" onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={4}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Title</InputLabel>
+                <Select
+                  value={formData.name?.title || ""}
+                  onChange={(e) => handleChange("name.title", e.target.value)}
+                  label="Title"
+                >
+                  <MenuItem value="Mr">Mr</MenuItem>
+                  <MenuItem value="Mrs">Mrs</MenuItem>
+                  <MenuItem value="Ms">Ms</MenuItem>
+                  <MenuItem value="Miss">Miss</MenuItem>
+                  <MenuItem value="Dr">Dr</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="First Name"
+                value={formData.name?.first || ""}
+                onChange={(e) => handleChange("name.first", e.target.value)}
+                fullWidth
+                size="small"
+                required
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                label="Last Name"
+                value={formData.name?.last || ""}
+                onChange={(e) => handleChange("name.last", e.target.value)}
+                fullWidth
+                size="small"
+                required
+              />
+            </Grid>
+          </Grid>
+
+          <TextField
+            label="Email"
+            type="email"
+            value={formData.email || ""}
+            onChange={(e) => handleChange("email", e.target.value)}
+            fullWidth
+            size="small"
+            required
+          />
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Phone"
+                value={formData.phone || ""}
+                onChange={(e) => handleChange("phone", e.target.value)}
+                fullWidth
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Cell"
+                value={formData.cell || ""}
+                onChange={(e) => handleChange("cell", e.target.value)}
+                fullWidth
+                size="small"
+              />
+            </Grid>
+          </Grid>
+
+          <FormControl fullWidth size="small">
+            <InputLabel>Gender</InputLabel>
+            <Select
+              value={formData.gender || ""}
+              onChange={(e) => handleChange("gender", e.target.value)}
+              label="Gender"
+            >
+              <MenuItem value="male">Male</MenuItem>
+              <MenuItem value="female">Female</MenuItem>
+            </Select>
+          </FormControl>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Street Number"
+                type="number"
+                value={formData.location?.street?.number || ""}
+                onChange={(e) =>
+                  handleChange("location.street.number", Number(e.target.value))
+                }
+                fullWidth
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Street Name"
+                value={formData.location?.street?.name || ""}
+                onChange={(e) =>
+                  handleChange("location.street.name", e.target.value)
+                }
+                fullWidth
+                size="small"
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="City"
+                value={formData.location?.city || ""}
+                onChange={(e) => handleChange("location.city", e.target.value)}
+                fullWidth
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="State"
+                value={formData.location?.state || ""}
+                onChange={(e) => handleChange("location.state", e.target.value)}
+                fullWidth
+                size="small"
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Country"
+                value={formData.location?.country || ""}
+                onChange={(e) =>
+                  handleChange("location.country", e.target.value)
+                }
+                fullWidth
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Postcode"
+                value={formData.location?.postcode || ""}
+                onChange={(e) =>
+                  handleChange("location.postcode", e.target.value)
+                }
+                fullWidth
+                size="small"
+              />
+            </Grid>
+          </Grid>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="contained" disabled={loading}>
+          {loading ? <CircularProgress size={24} /> : "Save Changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/components/EditUserModal.tsx
+++ b/src/crm/components/EditUserModal.tsx
@@ -14,8 +14,16 @@ import InputLabel from "@mui/material/InputLabel";
 import CircularProgress from "@mui/material/CircularProgress";
 import Alert from "@mui/material/Alert";
 
+/**
+ * Base URL for the Users API
+ * This API provides CRUD operations for user management
+ */
 const API_BASE_URL = "https://user-api.builder-io.workers.dev/api";
 
+/**
+ * Interface representing a user's physical location
+ * Contains address details including street, city, state, country, and postal code
+ */
 interface UserLocation {
   street: {
     number: number;
@@ -27,17 +35,29 @@ interface UserLocation {
   postcode: string;
 }
 
+/**
+ * Interface representing a user's name components
+ * Includes title (Mr, Mrs, etc.), first name, and last name
+ */
 interface UserName {
   title: string;
   first: string;
   last: string;
 }
 
+/**
+ * Interface representing user login credentials
+ * Contains unique identifier (UUID) and username
+ */
 interface UserLogin {
   uuid: string;
   username: string;
 }
 
+/**
+ * Main User interface representing a complete user object
+ * Contains all user information including personal details, contact info, and location
+ */
 interface User {
   login: UserLogin;
   name: UserName;
@@ -62,23 +82,54 @@ interface User {
   nat: string;
 }
 
+/**
+ * Props interface for the EditUserModal component
+ */
 interface EditUserModalProps {
+  /** Controls whether the modal is visible */
   open: boolean;
+  /** The user object to edit, or null if no user is selected */
   user: User | null;
+  /** Callback function to close the modal */
   onClose: () => void;
+  /** Callback function called after successfully saving user changes */
   onSave: (user: User) => void;
 }
 
+/**
+ * EditUserModal Component
+ * 
+ * A modal dialog for editing user information. Provides a comprehensive form
+ * for updating all user fields including name, contact information, and address.
+ * 
+ * Features:
+ * - Form validation for required fields
+ * - Loading state during API calls
+ * - Error handling with user-friendly messages
+ * - Nested object handling for complex data structures
+ * 
+ * @param props - Component props including open state, user data, and callbacks
+ * @returns A Material-UI Dialog with user edit form
+ */
 export default function EditUserModal({
   open,
   user,
   onClose,
   onSave,
 }: EditUserModalProps) {
+  // Loading state for API calls (shows spinner in save button)
   const [loading, setLoading] = React.useState(false);
+  
+  // Error message state for displaying API or validation errors
   const [error, setError] = React.useState<string | null>(null);
+  
+  // Form data state - starts as partial to handle incremental updates
   const [formData, setFormData] = React.useState<Partial<User>>({});
 
+  /**
+   * Effect to populate form when user prop changes
+   * Resets error state when a new user is loaded
+   */
   React.useEffect(() => {
     if (user) {
       setFormData(user);
@@ -86,29 +137,55 @@ export default function EditUserModal({
     }
   }, [user]);
 
+  /**
+   * Generic change handler for form fields
+   * Handles both flat and nested object properties
+   * 
+   * Examples:
+   * - "email" updates formData.email
+   * - "name.first" updates formData.name.first
+   * - "location.city" updates formData.location.city
+   * 
+   * @param field - Dot-notation path to the field (e.g., "name.first")
+   * @param value - New value for the field
+   */
   const handleChange = (field: string, value: any) => {
     setFormData((prev) => {
       const keys = field.split(".");
+      
+      // Handle simple, non-nested fields
       if (keys.length === 1) {
         return { ...prev, [field]: value };
       }
 
-      // Handle nested fields like "name.first" or "location.city"
+      // Handle nested fields using dot notation
+      // Creates a deep copy to avoid mutating state
       const newData = { ...prev };
       let current: any = newData;
+      
+      // Navigate to the parent object, creating missing intermediate objects
       for (let i = 0; i < keys.length - 1; i++) {
         if (!current[keys[i]]) {
           current[keys[i]] = {};
         } else {
+          // Clone the nested object to maintain immutability
           current[keys[i]] = { ...current[keys[i]] };
         }
         current = current[keys[i]];
       }
+      
+      // Set the final value
       current[keys[keys.length - 1]] = value;
       return newData;
     });
   };
 
+  /**
+   * Form submission handler
+   * Sends PUT request to API to update user data
+   * 
+   * @param e - Form submit event
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
@@ -117,6 +194,7 @@ export default function EditUserModal({
     setError(null);
 
     try {
+      // Send PUT request to update user
       const response = await fetch(
         `${API_BASE_URL}/users/${user.login.uuid}`,
         {
@@ -132,14 +210,18 @@ export default function EditUserModal({
         throw new Error("Failed to update user");
       }
 
+      // Call parent's save handler with updated data
       onSave(formData as User);
     } catch (err) {
+      // Display error message to user
       setError(err instanceof Error ? err.message : "Failed to update user");
     } finally {
+      // Always stop loading, regardless of success/failure
       setLoading(false);
     }
   };
 
+  // Don't render modal if no user is selected
   if (!user) return null;
 
   return (
@@ -156,12 +238,14 @@ export default function EditUserModal({
       <DialogTitle>Edit User</DialogTitle>
       <DialogContent>
         <Stack spacing={3} sx={{ mt: 2 }}>
+          {/* Error alert banner - only shown when error exists */}
           {error && (
             <Alert severity="error" onClose={() => setError(null)}>
               {error}
             </Alert>
           )}
 
+          {/* Name section: Title, First Name, Last Name */}
           <Grid container spacing={2}>
             <Grid item xs={12} sm={4}>
               <FormControl fullWidth size="small">
@@ -201,6 +285,7 @@ export default function EditUserModal({
             </Grid>
           </Grid>
 
+          {/* Email field - required */}
           <TextField
             label="Email"
             type="email"
@@ -211,6 +296,7 @@ export default function EditUserModal({
             required
           />
 
+          {/* Contact numbers: Phone and Cell */}
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -232,6 +318,7 @@ export default function EditUserModal({
             </Grid>
           </Grid>
 
+          {/* Gender selection */}
           <FormControl fullWidth size="small">
             <InputLabel>Gender</InputLabel>
             <Select
@@ -244,6 +331,7 @@ export default function EditUserModal({
             </Select>
           </FormControl>
 
+          {/* Address section: Street Number and Street Name */}
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -270,6 +358,7 @@ export default function EditUserModal({
             </Grid>
           </Grid>
 
+          {/* Address section: City and State */}
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -291,6 +380,7 @@ export default function EditUserModal({
             </Grid>
           </Grid>
 
+          {/* Address section: Country and Postcode */}
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -317,11 +407,14 @@ export default function EditUserModal({
           </Grid>
         </Stack>
       </DialogContent>
+      
+      {/* Modal action buttons */}
       <DialogActions>
         <Button onClick={onClose} disabled={loading}>
           Cancel
         </Button>
         <Button type="submit" variant="contained" disabled={loading}>
+          {/* Show spinner during API call, otherwise show text */}
           {loading ? <CircularProgress size={24} /> : "Save Changes"}
         </Button>
       </DialogActions>

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,18 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import CustomersUsersTable from "../components/CustomersUsersTable";
 
 export default function Customers() {
   return (
     <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+        Customers
       </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
+      <Typography paragraph sx={{ mb: 3, color: "text.secondary" }}>
+        Manage your customer data and user information
       </Typography>
+      <CustomersUsersTable />
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds a new Users table to the Customers page, featuring server-side pagination, search functionality, and a modal for editing user details.

## Problem
The Customers page was previously a placeholder. There was a need to visualize user data from the users API, search through records, and edit user information directly from the interface.

## Solution
Implemented a `CustomersUsersTable` component using MUI DataGrid to fetch and display data. Created an `EditUserModal` to handle user updates. Integrated these components into the main `Customers` page.

## Key Changes
- **New Users Table**: Displays user data (Avatar, Name, Email, Location, etc.) with server-side pagination.
- **Search Functionality**: Added a search bar to filter users by name, email, or city.
- **Edit Capability**: Implemented a modal containing a comprehensive form to edit user details (Name, Contact, Address).
- **API Integration**: Connected to the external users API for fetching lists and updating individual records.

## Files Changed
- `src/crm/components/CustomersUsersTable.tsx`: Created the main table component with search and data fetching logic.
- `src/crm/components/EditUserModal.tsx`: Created the modal component for editing user profile information.
- `src/crm/pages/Customers.tsx`: Updated the page layout to include the new users table.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/732f251a2f7347b08695f539bfd6f8a7/swoosh-hub)

👀 [Preview Link](https://732f251a2f7347b08695f539bfd6f8a7-swoosh-hub.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>732f251a2f7347b08695f539bfd6f8a7</projectId>-->
<!--<branchName>swoosh-hub</branchName>-->